### PR TITLE
Fixed landing page margin

### DIFF
--- a/src/css/landingpage.css
+++ b/src/css/landingpage.css
@@ -1,195 +1,199 @@
 html {
-    font-size: 16px;
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
 }
 
 .landingpage-body {
-    margin: 0;
-    background-color: #F5F5F5;
+  margin: 0;
+  background-color: #f5f5f5;
 }
 
 .landingpage-main-section {
-    display: grid;
-    grid-template-columns: auto;
-    grid-template-rows: auto;
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: auto;
 }
 
 .landingpage-div {
-    display: grid;
-    grid-template-rows: 1fr;
-    background-image: url(../../public/assets/img/heroimage-edugate.png);
-    max-width: 100%;
-    height: 18.75rem;
-    background-size: cover;
-    background-position: center;
+  display: grid;
+  grid-template-rows: 1fr;
+  background-image: url(../../public/assets/img/heroimage-edugate.png);
+  max-width: 100%;
+  height: 18.75rem;
+  background-size: cover;
+  background-position: center;
 }
 
 .landingpage-h1 {
-    margin: 0.6rem 0 0 0;
-    align-content: start;
-    text-align: center;
-    font-size: 2rem;
-    font-family: "Poppins", sans-serif;
-    font-weight: 700;
-    color: #333333;
+  margin: 0.6rem 0 0 0;
+  align-content: start;
+  text-align: center;
+  font-size: 2rem;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  color: #333333;
 }
 
 .landingpage-paragraph-text {
-    justify-content: end;
-    align-content: end;
-    padding: 0 2.5rem 0 2.5rem;
-    text-align: center;
-    font-size: 0.88rem;
-    font-family: "Roboto", sans-serif;
-    letter-spacing: 0.03rem;
-    color: #333333;
-    margin: 0 0 0.88rem 0;
+  justify-content: end;
+  align-content: end;
+  padding: 0 2.5rem 0 2.5rem;
+  text-align: center;
+  font-size: 0.88rem;
+  font-family: 'Roboto', sans-serif;
+  letter-spacing: 0.03rem;
+  color: #333333;
+  margin: 0 0 0.88rem 0;
 }
 
 .landingpage-button-div {
-    display: grid;
-    grid-row: 2;
+  display: grid;
+  grid-row: 2;
 }
 
 .landingpage-signup-btn {
-    width: 6.88rem;
-    height: 2.75rem;
-    font-size: 1rem;
-    justify-self: center;
-    color: #fff;
-    background-color: #4CAF50;
-    border-radius: 0.38rem;
-    border: none;
-    margin: 1rem 0 1rem 0;
-    font-family: "Poppins", sans-serif;
-    font-weight: 600;
-    letter-spacing: 0.5px;
+  width: 6.88rem;
+  height: 2.75rem;
+  font-size: 1rem;
+  justify-self: center;
+  color: #fff;
+  background-color: #4caf50;
+  border-radius: 0.38rem;
+  border: none;
+  margin: 1rem 0 1rem 0;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.5px;
 }
 
 .landingpage-signup-btn:hover {
-    background-color: #388E3C;
-    cursor: pointer;
+  background-color: #388e3c;
+  cursor: pointer;
 }
 
 .landingpage-login-btn {
-    width: 6.88rem;
-    height: 2.75rem;
-    font-size: 1rem;
-    justify-self: center;
-    align-self: center;    
-    background-color: #F5F5F5;
-    border-radius: 0.38rem;
-    border: 2px solid #2196F3;     
-    color: #2196F3;
-    font-family: "Poppins", sans-serif;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-    margin: 0 0 0.4rem 0;
+  width: 6.88rem;
+  height: 2.75rem;
+  font-size: 1rem;
+  justify-self: center;
+  align-self: center;
+  background-color: #f5f5f5;
+  border-radius: 0.38rem;
+  border: 2px solid #2196f3;
+  color: #2196f3;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  margin: 0 0 0.4rem 0;
 }
 
 .landingpage-login-btn:hover {
-    background-color: #BBDEFB;
-    cursor: pointer;
+  background-color: #bbdefb;
+  cursor: pointer;
 }
 
 @media only screen and (min-width: 767px) {
-    .landingpage-main-section {
-        display: grid;
-        background-image: url(../../public/assets/img/heroimage-edugate.png);
-        max-width: 100%;
-        height: 45rem;
-        background-size: cover;
-        background-position: center;
-    }
+  .landingpage-main-section {
+    display: grid;
+    background-image: url(../../public/assets/img/heroimage-edugate.png);
+    max-width: 100%;
+    height: 45rem;
+    background-size: cover;
+    background-position: center;
+  }
 
-    .landingpage-div {
-        background-image: none;
-        display: flex;
-        flex-direction: column;
-        justify-self: center;
-    }
+  .landingpage-div {
+    background-image: none;
+    display: flex;
+    flex-direction: column;
+    justify-self: center;
+  }
 
-      .landingpage-button-div {
-        display: flex;
-        flex-basis: fit-content;
-        justify-content: center;
-        align-self: end;
-        column-gap: 1.50rem;
-        margin: 0;
-    }
+  .landingpage-button-div {
+    display: flex;
+    flex-basis: fit-content;
+    justify-content: center;
+    align-self: end;
+    column-gap: 1.5rem;
+    margin: 0;
+  }
 
-    .landingpage-h1 {
-        margin-top: 0;
-        grid-row: 1;
-        margin-top: 3.31rem;      
-    }
+  .landingpage-h1 {
+    margin-top: 0;
+    grid-row: 1;
+    margin-top: 3.31rem;
+  }
 
-    .landingpage-paragraph-text {
-        margin: 0;
-        padding: 0;
-        font-size: 1rem;
-    }
+  .landingpage-paragraph-text {
+    margin: 0;
+    padding: 0;
+    font-size: 1rem;
+  }
 
-    .landingpage-signup-btn {
-        margin: 0 0 4rem 0;
-        font-size: 1.50rem;
-        font-weight: 700;
-        width: 8.31rem;
-        height: 3.69rem;
-        line-height: 0.13rem;
-        letter-spacing: 0.06rem;
-    }
+  .landingpage-signup-btn {
+    margin: 0 0 4rem 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    width: 8.31rem;
+    height: 3.69rem;
+    line-height: 0.13rem;
+    letter-spacing: 0.06rem;
+  }
 
-    .landingpage-login-btn {
-        background-color: transparent;
-        margin: 0 0 4rem 0;
-        font-size: 1.63rem;
-        font-weight: 700;
-        width: 7.38rem;
-        height: 3.69rem;
-        line-height: 0.13rem;
-        letter-spacing: 0.06rem;
-    }
+  .landingpage-login-btn {
+    background-color: transparent;
+    margin: 0 0 4rem 0;
+    font-size: 1.63rem;
+    font-weight: 700;
+    width: 7.38rem;
+    height: 3.69rem;
+    line-height: 0.13rem;
+    letter-spacing: 0.06rem;
+  }
 }
 
 @media only screen and (min-width: 1460px) {
-    .landingpage-main-section {
-        height: 59rem;
-    }
+  .landingpage-main-section {
+    height: 59rem;
+  }
 
-    .landingpage-signup-btn, .landingpage-login-btn {
-        margin: 0 0 4.5rem 0;
-    }
+  .landingpage-signup-btn,
+  .landingpage-login-btn {
+    margin: 0 0 4.5rem 0;
+  }
 
-    .landingpage-h1 {
-        margin: 3.31rem 0 0.2rem 0;
-    
-    }
+  .landingpage-h1 {
+    margin: 3.31rem 0 0.2rem 0;
+  }
 }
 
 @media only screen and (min-width: 2559px) {
-    .landingpage-main-section {
-        height: 76rem;
-    }
+  .landingpage-main-section {
+    height: 76rem;
+  }
 
-    .landingpage-h1 {
-        font-size: 3.7rem;
-    }
+  .landingpage-h1 {
+    font-size: 3.7rem;
+  }
 
-    .landingpage-paragraph-text {
-        font-size: 1.7rem;
-    }
+  .landingpage-paragraph-text {
+    font-size: 1.7rem;
+  }
 
-    .landingpage-signup-btn, .landingpage-login-btn {
-        height: 6.4rem;
-        font-size: 2.3rem;
-    }
+  .landingpage-signup-btn,
+  .landingpage-login-btn {
+    height: 6.4rem;
+    font-size: 2.3rem;
+  }
 
-    .landingpage-signup-btn {
-        width: 12rem;
-    }
+  .landingpage-signup-btn {
+    width: 12rem;
+  }
 
-     .landingpage-login-btn {
-        width: 11rem;
-     }
+  .landingpage-login-btn {
+    width: 11rem;
+  }
 }
-


### PR DESCRIPTION
## Description

Small fix
---

## Related Issue(s)

Closes #46 
Closes #47

---

## Changes Made

- [x] Set landing page margin to 0 to stop images from scaling wrong

---

## Acceptance Criteria


- [x] Changes have been tested locally (mobile + desktop)
- [x] Follows the style guide and naming conventions (e.g. kebab-case)
- [x] Matches design spec (e.g. from Figma)
- [x] No `console.log` or warnings
- [x] All images have `alt` text
- [x] Headings follow correct order (no skipping levels)
